### PR TITLE
Added missing dependency crcmod

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
             ],
     },
 
-    install_requires=['boto', 'psutil'],
+    install_requires=['boto', 'crcmod', 'psutil'],
 
     # These will be in the package subdirectory, accessible by package code
     # package_data={


### PR DESCRIPTION
Did not test (and installed crcmod manually) as I wasn't completely sure how to (never developed packages for pip yet), but don't see anything that should break here.
