### PR TITLE
use -f flag to rm in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install : buttersink/version.py
 
 .PHONY : clean
 clean : clean_setup
-	rm -rf make
+	rm -rf make makestamps
 
 .PHONY : pypi
 pypi : buttersink/version.py

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ makestamps :
 .PHONY : clean_setup
 clean_setup :
 	./setup.py clean
-	sudo rm -r build dist buttersink.egg-info 2>/dev/null || true
+	sudo rm -rf build dist buttersink.egg-info
 
 .PHONY : install
 install : buttersink/version.py
@@ -29,7 +29,7 @@ install : buttersink/version.py
 
 .PHONY : clean
 clean : clean_setup
-	rm -r make 2>/dev/null || true
+	rm -rf make
 
 .PHONY : pypi
 pypi : buttersink/version.py


### PR DESCRIPTION
The current way of running `rm` in the makefile is weird. If the intent is to avoid errors when the files to be removed do not exist, why not use the `-f` flag? That way, other errors (e.g., permissions) will not be ignored.

Edit: by the way, when investigating #24, it turns out that make clean does not clean the makestamps, which I also fixed.
