### PR TITLE
Add option not to rely on quota

### DIFF
--- a/buttersink/BestDiffs.py
+++ b/buttersink/BestDiffs.py
@@ -302,7 +302,12 @@ class BestDiffs:
         """ Return all diffs used in optimal network. """
         nodes = self.nodes.values()
         nodes.sort(key=lambda node: (self._height(node), node.volume.otime))
+
         for node in nodes:
+            # we are not interested in those already transferred
+            if node.volume in self.dest.paths:
+                continue
+
             yield node.diff
             # yield { 'from': node.previous, 'to': node.uuid, 'sink': node.diffSink,
 

--- a/buttersink/BestDiffs.py
+++ b/buttersink/BestDiffs.py
@@ -74,11 +74,11 @@ class _Node:
             if n.diff is None:
                 continue
 
-            total.size += n.diff.size
+            total.size += (n.diff.size or 0)
 
             sink = sinks[n.diff.sink]
             sink.count += 1
-            sink.size += n.diff.size
+            sink.size += (n.diff.size or 0)
 
         sinksSorted = collections.OrderedDict(
             {s: b for s, b in sinks.items() if s is not None}
@@ -205,7 +205,7 @@ class BestDiffs:
 
                         logger.debug("Considering %s", edge)
 
-                        edgeSize = edge.size
+                        edgeSize = (edge.size or 0)
                         if edge.sizeIsEstimated:
                             if willMeasureLater:
                                 # Slight preference for accurate sizes

--- a/buttersink/BestDiffs.py
+++ b/buttersink/BestDiffs.py
@@ -160,7 +160,7 @@ class BestDiffs:
         def sortKey(node):
             if node is None:
                 return None
-            return (node.intermediate, self._totalSize(node))
+            return (node.intermediate, self._totalSize(node), node.volume.otime)
 
         while len(nodes) > 0:
             logger.debug("Analyzing %d nodes for height %d...", len(nodes), height)
@@ -301,7 +301,7 @@ class BestDiffs:
     def iterDiffs(self):
         """ Return all diffs used in optimal network. """
         nodes = self.nodes.values()
-        nodes.sort(key=lambda node: self._height(node))
+        nodes.sort(key=lambda node: (self._height(node), node.volume.otime))
         for node in nodes:
             yield node.diff
             # yield { 'from': node.previous, 'to': node.uuid, 'sink': node.diffSink,

--- a/buttersink/ButterStore.py
+++ b/buttersink/ButterStore.py
@@ -335,3 +335,6 @@ class ButterStore(Store.Store):
             if self._skipDryRun(logger, 'INFO', dryrun=dryrun)("Delete subvolume %s", path):
                 continue
             self.butterVolumes[vol.uuid].destroy()
+
+    def rescanSizes(self):
+        self.btrfs.rescanSizes()

--- a/buttersink/ButterStore.py
+++ b/buttersink/ButterStore.py
@@ -59,7 +59,7 @@ class ButterStore(Store.Store):
         if uuid is None:
             return None
 
-        return Store.Volume(uuid, gen, bvol.totalSize, bvol.exclusiveSize)
+        return Store.Volume(uuid, gen, bvol.totalSize, bvol.exclusiveSize, bvol.otime)
 
     def _fillVolumesAndPaths(self, paths):
         """ Fill in paths.

--- a/buttersink/Store.py
+++ b/buttersink/Store.py
@@ -390,13 +390,14 @@ class Volume:
 
     """ Represents a snapshot. """
 
-    def __init__(self, uuid, gen, size=None, exclusiveSize=None):
+    def __init__(self, uuid, gen, size=None, exclusiveSize=None, otime=None):
         """ Initialize. """
         assert uuid is not None
         self._uuid = uuid  # Must never change!
         self.size = size
         self.exclusiveSize = exclusiveSize
         self.gen = gen
+        self.otime = otime
 
     def __cmp__(self, vol):
         """ Compare. """

--- a/buttersink/btrfs.py
+++ b/buttersink/btrfs.py
@@ -495,7 +495,6 @@ class FileSystem(ioctl.Device):
         self._getDevices()
         self._getRoots()
         self._getMounts()
-        self._getUsage()
 
         volumes = self.volumes.values()
         volumes.sort(key=(lambda v: v.fullPath))
@@ -669,16 +668,16 @@ class FileSystem(ioctl.Device):
                     self.defaultID = info.location.objectid
                 logger.debug("Found dir '%s' is %d", name, self.defaultID)
 
-    def _getUsage(self):
+    def rescanSizes(self):
         try:
             self._rescanSizes(False)
-            self._unsafeGetUsage()
+            self._getUsage()
         except (IOError, _BtrfsError) as error:
             logger.warn("%s", error)
             self._rescanSizes()
-            self._unsafeGetUsage()
+            self._getUsage()
 
-    def _unsafeGetUsage(self):
+    def _getUsage(self):
         for (header, buf) in self._walkTree(BTRFS_QUOTA_TREE_OBJECTID):
             # logger.debug("%s %s", objectTypeNames[header.type], header)
 

--- a/buttersink/btrfs.py
+++ b/buttersink/btrfs.py
@@ -15,6 +15,7 @@ import ioctl
 import logging
 import os.path
 
+
 logger = logging.getLogger(__name__)
 # logger.setLevel('DEBUG')
 
@@ -374,6 +375,11 @@ class _Volume(object):
         self.info = info
 
         self.links = {}
+
+        # Snapshot creation time in seconds.
+        # Some accuracy is lost
+        otime_total_ns = info.otime.sec * (10 ** 9) + info.otime.nsec
+        self.otime = otime_total_ns / float(10 ** 9)
 
         assert rootid not in self.fileSystem.volumes, rootid
         self.fileSystem.volumes[rootid] = self

--- a/buttersink/progress.py
+++ b/buttersink/progress.py
@@ -58,7 +58,12 @@ class DisplayProgress(object):
 
         elapsed = now - self.startTime
 
-        if sent > 0 and self.total is not None and sent <= self.total:
+        if all([
+                sent > 0,
+                self.total is not None,
+                self.total != 0,
+                sent <= self.total,
+                ]):
             eta = (self.total - sent) * elapsed.total_seconds() / sent
             eta = datetime.timedelta(seconds=eta)
         else:
@@ -68,8 +73,8 @@ class DisplayProgress(object):
             "\r %s: Sent %s%s%s ETA: %s (%s) %s%20s\r" % (
                 elapsed,
                 util.humanize(sent),
-                "" if self.total is None else " of %s" % (util.humanize(self.total),),
-                "" if self.total is None else " (%d%%)" % (int(100 * sent / self.total),),
+                "" if (self.total is None or self.total == 0) else " of %s" % (util.humanize(self.total),),
+                "" if (self.total is None or self.total == 0) else " (%d%%)" % (int(100 * sent / self.total),),
                 eta,
                 "" if not mbps else "%.3g Mbps " % (mbps,),
                 chunk or "",


### PR DESCRIPTION
Now double `-e` (`-ee`) option imply `noQuota` mode.
In `noQuota` mode snapshot ordering is done by `otime` value.